### PR TITLE
feat: automatically publish floating tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,46 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
 
 jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.metadata.outputs.tag_name }}
+    steps:
+      - name: Prepare release metadata
+        id: metadata
+        uses: apify/actions/git-cliff-release@main
+        with:
+          release_type: auto
+
+      - name: Create release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.metadata.outputs.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ steps.metadata.outputs.tag_name }}" \
+            --notes "${{ steps.metadata.outputs.release_notes }}"
+
+          echo "release_created=true" >> "$GITHUB_OUTPUT"
+
   floating-tags:
     name: Publish floating tags
+    needs: release
+    if: needs.release.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Publish floating tags
-        uses: actions/publish-action@v0.3.0
+        uses: actions/publish-action@v0.4.0
         with:
-          source-tag: ${{ github.event.release.tag_name }}
+          source-tag: ${{ needs.release.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  floating-tags:
+    name: Publish floating tags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish floating tags
+        uses: actions/publish-action@v0.3.0
+        with:
+          source-tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- closes #4 
- Adds `.github/workflows/release.yml` that triggers on every published release
- Uses [`actions/publish-action@v0.3.0`](https://github.com/actions/publish-action) to automatically move the floating major version tag (e.g. `v1`) to point at the newly released commit whenever a version like `v1.2.3` is published

## Why

Users referencing `uses: apify/setup-apify-cli-action@v1` in their workflows expect to always get the latest `v1.x.x` release. Without this workflow the `v1` tag was never updated, so it stayed stuck at the first `v1` release. This is the same pattern as referenced in https://github.com/apify/crawlee-python/pull/1880.

## Test plan

- [ ] Create a new GitHub release (e.g. `v1.0.1`) and confirm the `v1` tag is moved to that commit
- [ ] Confirm that a workflow using `@v1` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)